### PR TITLE
refactor: simplify structure of basecomp

### DIFF
--- a/avfcomp/base.py
+++ b/avfcomp/base.py
@@ -4,7 +4,7 @@ from io import SEEK_CUR
 from typing import Dict, List, Tuple
 
 from . import config
-from .basecomp import CompType, T_CompFile, T_CompType, copen
+from .basecomp import CompType, T_CompFile, copen
 
 
 class AVFParser:
@@ -156,7 +156,7 @@ class AVFParser:
         # section => extract game time from the second to last event
         self.read_footer(fin)
 
-    def process_in(self, filename: str, in_type: T_CompType = CompType.PLAIN):
+    def process_in(self, filename: str, in_type: CompType = CompType.PLAIN):
         """Process the AVF file and parse the data to memory."""
         with copen(filename, "rb", _type=in_type) as fin:
             self.read_data(fin)
@@ -223,7 +223,7 @@ class AVFParser:
 
         self.write_footer(fout)
 
-    def process_out(self, filename: str, out_type: T_CompType = CompType.PLAIN):
+    def process_out(self, filename: str, out_type: CompType = CompType.PLAIN):
         """Process the AVF file and write the output to a file."""
         with copen(filename, "wb", out_type) as fout:
             self.write_data(fout)

--- a/avfcomp/basecomp.py
+++ b/avfcomp/basecomp.py
@@ -1,36 +1,25 @@
 """Base compression library which deals with multiple compression formats."""
 
 from bz2 import BZ2File
-from enum import IntEnum
+from enum import Enum
 from gzip import GzipFile
 from io import BufferedReader, BufferedWriter
 from lzma import LZMAFile
 from typing import Literal, Union
 
 
-class CompType(IntEnum):
+class CompType(Enum):
     """Compression type."""
-    PLAIN = 0
-    GZIP = 1
-    BZIP2 = 2
-    LZMA = 3
+    PLAIN = None
+    GZIP = GzipFile
+    BZIP2 = BZ2File
+    LZMA = LZMAFile
 
 T_CompFile = Union[BufferedReader, BufferedWriter, GzipFile, BZ2File, LZMAFile]
-T_CompType = Literal[CompType.PLAIN, CompType.GZIP, CompType.BZIP2, CompType.LZMA]
 
 
-def copen(filename: str, mode: Literal["rb", "wb"], _type: T_CompType, **kwargs) -> T_CompFile:
+def copen(filename: str, mode: Literal["rb", "wb"], _type: CompType, **kwargs) -> T_CompFile:
     """Open a file with a compression format."""
-    if _type == CompType.PLAIN:
+    if _type == CompType.PLAIN:  # special case, just open the file
         return open(filename, mode, **kwargs)
-
-    if _type == CompType.GZIP:
-        return GzipFile(filename, mode, **kwargs)
-
-    if _type == CompType.BZIP2:
-        return BZ2File(filename, mode, **kwargs)
-
-    if _type == CompType.LZMA:
-        return LZMAFile(filename, mode, **kwargs)
-
-    raise ValueError("Unknown compression type.")
+    return _type.value(filename, mode, **kwargs)

--- a/avfcomp/comp.py
+++ b/avfcomp/comp.py
@@ -1,7 +1,6 @@
 """Compression of an AVF file."""
 
 from typing import List
-from lzma import LZMAFile
 
 from .base import AVFParser
 

--- a/avfcomp/decomp.py
+++ b/avfcomp/decomp.py
@@ -1,7 +1,6 @@
 """Decompression of an AVF file."""
 
 from typing import List
-from lzma import LZMAFile
 
 from .base import AVFParser
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -8,7 +8,6 @@ from os import listdir, mkdir, path
 from typing import Any, Callable, Iterator, Tuple
 
 from avfcomp import AVFComp, AVFDecomp, CompType
-from avfcomp.basecomp import T_CompType
 
 work_dir = path.dirname(path.dirname(__file__))
 
@@ -53,7 +52,7 @@ def cost_time(func: Callable) -> Callable[..., Tuple[Any, float]]:
 
 
 @cost_time
-def get_comp(paths: str, method: T_CompType) -> Tuple[int, int]:
+def get_comp(paths: str, method: CompType) -> Tuple[int, int]:
     """Compress all files."""
     rawsize = 0
     compsize = 0
@@ -68,7 +67,7 @@ def get_comp(paths: str, method: T_CompType) -> Tuple[int, int]:
 
 
 @cost_time
-def get_decomp(paths: str, method: T_CompType) -> Tuple[int, int]:
+def get_decomp(paths: str, method: CompType) -> Tuple[int, int]:
     """Decompress all files."""
     decompsize_in = 0
     decompsize_out = 0
@@ -82,7 +81,7 @@ def get_decomp(paths: str, method: T_CompType) -> Tuple[int, int]:
     return (decompsize_in, decompsize_out)
 
 
-def stat_comp(paths: str, method: T_CompType, mode: str = ""):
+def stat_comp(paths: str, method: CompType, mode: str = ""):
     """Get the statistics of compressed files."""
     size, ctime = get_comp(paths, method)
     compsize, rawsize = size
@@ -91,7 +90,7 @@ def stat_comp(paths: str, method: T_CompType, mode: str = ""):
     print(f"{mode}: {ratio:.2f}% {speed:.2f} MB/s")
 
 
-def stat_decomp(paths: str, method: T_CompType):
+def stat_decomp(paths: str, method: CompType):
     """Get the statistics of decompressed files."""
     size, dtime = get_decomp(paths, method)
     in_size, out_size = size
@@ -109,7 +108,7 @@ class TestCompAndDecomp(unittest.TestCase):
             decomp = path.join(decomp_path, name)
             self.assertEqual(calc_file_hash(file_path), calc_file_hash(decomp))
 
-    def comp_and_decomp(self, method: T_CompType):
+    def comp_and_decomp(self, method: CompType):
         """Test compression and decompression."""
         print("Refresh data directory: ")
         refresh()
@@ -128,7 +127,7 @@ class TestCompAndDecomp(unittest.TestCase):
     def test_lzma(self):
         """Test lzma compression and decompression."""
         print("Test lzma compression and decompression: ")
-        self.comp_and_decomp(CompType.LZMA)
+        self.comp_and_decomp(CompType.PLAIN)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To make Pylance happy, we have to add a particular case for the open() function, which is unnecessary.